### PR TITLE
Cleaning ChangeLog.md

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,3 +6,7 @@ dist_doc_DATA = README COPYING.txt GFDLv1.3.txt ChangeLog.md
 ChangeLog.md:
 	$(am__cd) $(top_srcdir) && ./generate-changelog.sh \
 	  > $(abs_top_builddir)/$@
+
+.PHONY: clean-local
+clean-local:
+	rm -f ChangeLog.md


### PR DESCRIPTION
When cleaning the source tree, this file is remaining and we don't revert to the
exact initial source tree.
