### PR TITLE
Sync hwcap table with kernel

### DIFF
--- a/src/auxv/hwcap.h
+++ b/src/auxv/hwcap.h
@@ -50,7 +50,9 @@
 #define PPC_FEATURE2_HAS_ISEL          0x08000000 /* Integer Select */
 #define PPC_FEATURE2_HAS_TAR           0x04000000 /* Target Address Register */
 #define PPC_FEATURE2_HAS_VEC_CRYPTO    0x02000000 /* Target supports vector
-						     instructions.  */
+                                                     instructions.  */
+#define PPC_FEATURE2_HTM_NOSC          0x01000000 /* Kernel aborts transactions
+                                                     in syscall */
 
 #endif /* __powerpc__  */
 

--- a/src/lsauxv.c
+++ b/src/lsauxv.c
@@ -195,6 +195,9 @@ static void print_hwcap(void)
 
 	if (hwcap_mask2 & PPC_FEATURE2_HAS_VEC_CRYPTO)
 	    printf("  HAS VEC CRYPTO\n");
+
+	if (hwcap_mask2 & PPC_FEATURE2_HTM_NOSC)
+	    printf("  HTM NOSC\n");
 #endif
 }
 


### PR DESCRIPTION
The kernel recently added support for aborting transactions
when entering a syscall. This support can be identified via
the HWCAP2 bits.
